### PR TITLE
Update example.com.conf https

### DIFF
--- a/sites-available/example.com.conf
+++ b/sites-available/example.com.conf
@@ -101,6 +101,16 @@ server {
     access_log  /var/log/nginx/example.com_access.log;
     error_log   /var/log/nginx/example.com_error.log;
 
+    ## See the blacklist.conf file at the parent dir: /etc/nginx.
+    ## Deny access based on the User-Agent header.
+    if ($bad_bot) {
+        return 444;
+    }
+    ## Deny access based on the Referer header.
+    if ($bad_referer) {
+        return 444;
+    }
+
     ## Keep alive timeout set to a greater value for SSL/TLS.
     keepalive_timeout 75 75;
 
@@ -114,6 +124,7 @@ server {
     ## whichever age you want.
     add_header Strict-Transport-Security "max-age=7200";
 
+    ## Filesystem root of the site and index.
     root /var/www/sites/example.com;
     index index.php;
 
@@ -125,55 +136,25 @@ server {
     ## Uncomment if you're proxying to Apache for handling PHP.
     #proxy_http_version 1.1; # keep alive to the Apache upstream
 
-    ## See the blacklist.conf file at the parent dir: /etc/nginx.
-    ## Deny access based on the User-Agent header.
-    if ($bad_bot) {
-        return 444;
-    }
-    ## Deny access based on the Referer header.
-    if ($bad_referer) {
-        return 444;
-    }
-
     ################################################################
-    ### Generic configuration: for most Drupal 6 and Drupal 7 sites.
+    ### Generic configuration: for most Drupal 7 sites.
     ################################################################
-    ## This configuration is only for
-    ## sites that don't rely on the usage of
-    ## http://api.drupal.org/api/drupal/developer--hooks--core.php/function/custom_url_rewrite_outbound/6
-    ## like http://drupal.org/project/purl and modules that make use
-    ## if it like http://drupal.org/project/spaces,
     include sites-available/drupal.conf;
 
     ################################################################
-    ### Configuration for sites that use
-    ### http://drupal.org/project/purl or rely on custom URL rewrites
-    ### implemented on modules via
-    ### http://api.drupal.org/api/drupal/developer--hooks--core.php/function/custom_url_rewrite_outbound/6
-    ### This is suitable for OpenAtrium (http://openatrium.com) or
-    ### Managing News (http://managingnews.com).
+    ### Generic configuration: for most Drupal 6 sites.
     ################################################################
-    #include sites-available/drupal_spaces.conf;
+    # include sites-available/drupal6.conf;
 
     #################################################################
-    ### Configuration for Drupal sites that use boost.
+    ### Configuration for Drupal 7 sites that use boost.
     #################################################################
-    ## This configuration is only for
-    ## sites that don't rely on the usage of
-    ## http://api.drupal.org/api/drupal/developer--hooks--core.php/function/custom_url_rewrite_outbound/6
-    ## like http://drupal.org/project/purl and modules that make use
-    ## if it like http://drupal.org/project/spaces,
     #include sites-available/drupal_boost.conf;
 
     #################################################################
-    ### Configuration for Drupal sites using Boost and have installed
-    ### the module http://drupal.org/project/purl or rely on custom
-    ### URL rewrites implemented on modules via
-    ### http://api.drupal.org/api/drupal/developer--hooks--core.php/function/custom_url_rewrite_outbound/6
-    ### This is suitable for OpenAtrium (http://openatrium.com) or
-    ### Managing News (http://managingnews.com).
+    ### Configuration for Drupal 6 sites that use boost.
     #################################################################
-    #include sites-available/drupal_spaces_boost.conf;
+    #include sites-available/drupal_boost6.conf;
 
     #################################################################
     ### Configuration for updating the site via update.php and running
@@ -203,7 +184,7 @@ server {
 
     ## Including the php-fpm status and ping pages config.
     ## Uncomment to enable if you're running php-fpm.
-    #include php_fpm_status.conf;
+    #include php_fpm_status_vhost.conf;
 
     ## Including the Nginx stub status page for having stats about
     ## Nginx activity: http://wiki.nginx.org/HttpStubStatusModule.


### PR DESCRIPTION
António,

I believe you forgot the HTTPS section of example.com.conf.

I updated it according to the changes in the HTTP server and moved a couple of bits so they're in the same relative position in both `server` declarations. I'm just not sure about the `location @fallback` section, which exists in the HTTPS server but not in the HTTP server, but since I don't know your configuration that well, I thought I'd leave it in and you could remove it if it's not necessary.

Raúl
