### PR TITLE
Typo fix for README as Drupal 7 was referenced as Drupal 6 in a crucial spot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ version.
   * On **drupal 7** use the `drupal.conf` config in your vhost
     (`server` block): `include sites-availables/drupal.conf;`.
     
-  * On **drupal 6** having to serve URIs that need to be **escaped**,
+  * On **drupal 7** having to serve URIs that need to be **escaped**,
     e.g., that have `+` and/or `?` then use the `drupal_escaped.conf`
     config in your vhost (`server` block): 
     `include sites-available/drupal_escaped.conf`.


### PR DESCRIPTION
Self explanatory fix, see title. Also saw "Ad and Aditional" near the bottom in a heading. (Additional missing one d?)

Nice work, by the way. I'm thinking of incorporating this into a puppet script for deployment with Vagrant.
