### PR TITLE
Put $scheme in the cache key.

### DIFF
--- a/apps/drupal/microcache_fcgi.conf
+++ b/apps/drupal/microcache_fcgi.conf
@@ -6,7 +6,7 @@
 ## The cache zone referenced.
 fastcgi_cache microcache;
 ## The cache key.
-fastcgi_cache_key $host$request_uri;
+fastcgi_cache_key $scheme$host$request_uri;
 
 ## For 200 and 301 make the cache valid for 1s seconds.
 fastcgi_cache_valid 200 301 15s;

--- a/apps/drupal/microcache_fcgi_auth.conf
+++ b/apps/drupal/microcache_fcgi_auth.conf
@@ -3,7 +3,7 @@
 ## The cache zone referenced.
 fastcgi_cache microcache;
 ## The cache key.
-fastcgi_cache_key $cache_uid@$host$request_uri;
+fastcgi_cache_key $cache_uid@$scheme$host$request_uri;
 
 ## For 200 and 301 make the cache valid for 15s.
 fastcgi_cache_valid 200 301 15s;


### PR DESCRIPTION
This ensures that HTTP and HTTPS pages are cached separately. This is
especially important when Drupal is using a module like securepages,
where /user on the HTTP side will just be a redirect to the HTTPS
version of the login form.
