### PR TITLE
Specified destination path for git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ HTTPS servers.
    
  2. Clone the git repository from github:
   
-        git clone https://github.com/perusio/drupal-with-nginx.git
+        git clone https://github.com/perusio/drupal-with-nginx.git /etc/nginx
   
     If you want to use only the Drupal specific version configuration
     you must do one of the checkouts below: 


### PR DESCRIPTION
Hi,

I think it would be clearer to mention destination path for git clone command here https://github.com/perusion/drupal-with-nginx/blob/master/README.md#installation

One guy asked me what he should do next if after execution of clone command he has /home/username/drupal-with-nginx . The documentation doesn't contain necessary step for copying configs to /etc/nginx.

What do you think?
