### PR TITLE
Correction to fastcgi microcache duration to bring it to 1s

### DIFF
--- a/apps/drupal/microcache_fcgi.conf
+++ b/apps/drupal/microcache_fcgi.conf
@@ -9,7 +9,7 @@ fastcgi_cache microcache;
 fastcgi_cache_key $scheme$host$request_uri;
 
 ## For 200 and 301 make the cache valid for 1s seconds.
-fastcgi_cache_valid 200 301 15s;
+fastcgi_cache_valid 200 301 1s;
 ## For 302 make it valid for 1 minute.
 fastcgi_cache_valid 302 1m;
 ## For 404 make it valid 1 second.


### PR DESCRIPTION
Corrected typo that meant 200 and 301 responses were valid for 15 seconds, not 1 second as specified in the comment
