### PR TITLE
Added section re: nginx message [emerg] could not build the va...

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -128,6 +128,19 @@ http {
     ## logs. Cf. http://wiki.nginx.org/NginxOptimizations.
     #map_hash_bucket_size 192;
 
+    ## Uncomment one of the lines below if you start getting this message:
+    ## "[emerg] could not build the variables_hash, you should increase
+    ## either variables_hash_max_size: 512 or variables_hash_bucket_size: 64"
+    ## You only need to increase one. Increasing variables_hash_max_size to 1024
+    ## was recommended in nginx forum by developers.
+    ## See this forum topic and responses
+    ## http://forum.nginx.org/read.php?2,192277,192286#msg-192286
+    ## See http://wiki.nginx.org/HttpCoreModule#variables_hash_bucket_size
+    ## The line variables_hash_bucket_size was added for completeness but not
+    ## changed from default.
+    #variables_hash_max_size 1024; # default 512
+    #variables_hash_bucket_size 64; # default is 64
+
     ## For the filefield_nginx_progress module to work. From the
     ## README. Reserve 1MB under the name 'uploads' to track uploads.
     upload_progress uploads 1m;


### PR DESCRIPTION
Ran into a problem with nginx "[emerg] could not build the variables_hash, you should increase either variables_hash_max_size: 512 or variables_hash_bucket_size: 64"

Based on discussion on nginx mailing list, I added this to my config and uncommented variables_hash_max_size to 1024 as this was recommended in nginx forum by developers.

Terry
