### PR TITLE
suggest some fixes/improvements

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -153,6 +153,10 @@ http {
     ## Block MIME type sniffing on IE.
     add_header X-Content-Options nosniff;
 
+    ## Increase variables hash table
+    ## See http://nginx.org/en/docs/hash.html
+    variables_hash_max_size 1024;
+
     ## Include the upstream servers for PHP FastCGI handling config.
     ## This one uses the FCGI process listening on TCP sockets.
     include upstream_phpcgi_tcp.conf;

--- a/php_fpm_status_vhost.conf
+++ b/php_fpm_status_vhost.conf
@@ -60,7 +60,7 @@ location = /fpm-status-drei {
     if ($dont_show_fpm_status) {
         return 404;
     }
-    fastcgi_pass phpcgi;
+    fastcgi_pass www2;
 }
 
 ## The ping page is at /ping and returns the string configured at the php-fpm level.
@@ -69,5 +69,5 @@ location = /ping-drei {
     if ($dont_show_fpm_status) {
         return 404;
     }
-    fastcgi_pass phpcgi;
+    fastcgi_pass www2;
 }

--- a/upstream_phpcgi_unix.conf
+++ b/upstream_phpcgi_unix.conf
@@ -46,3 +46,8 @@ upstream www0 {
 upstream www1 {
     server unix:/var/run/php-fpm-zwei.sock;
 }
+
+## The PHP TCP upstream that corresponds to the third pool: www2.
+upstream www2 {
+    server unix:/var/run/php-fpm-drei.sock;
+}


### PR DESCRIPTION
While setting my nginx up and learning a lot from your config I found a few issues that I had to struggle with. While some are specific to my machine I am suggesting a few that might be good to improve.

First is to increase variables_hash_max_size. I'd think this is specific to me, but is a plain debian testing  install on a 1gb rackspace performance server and getting that with your config out of the box, might be godo to have it as default, wondering what you thing?

Then the other bits are related to the php-fpm status pages that needed some small tweaks matching your suggested php-fpm configuration.
