### PR TITLE
Update microcache_fcgi.conf

### DIFF
--- a/apps/drupal/microcache_fcgi.conf
+++ b/apps/drupal/microcache_fcgi.conf
@@ -6,7 +6,7 @@
 ## The cache zone referenced.
 fastcgi_cache microcache;
 ## The cache key.
-fastcgi_cache_key $scheme$host$request_uri;
+fastcgi_cache_key $scheme$request_method$host$request_uri;
 
 ## For 200 and 301 make the cache valid for 1s seconds.
 fastcgi_cache_valid 200 301 1s;


### PR DESCRIPTION
See recommendations on:
http://wiki.nginx.org/HttpFastcgiModule#fastcgi_cache_key

fastcgi_cache_key "$scheme$request_method$host$request_uri";
Be advised that a HEAD request can cause an empty response to be cached & later be distributed to GET requests, avoid this by having $request_method in the cache key. Including the $scheme for the same reason may be beneficial to avoid serving up pages with insecure content to HTTPS visitors (or vice-versa).
