### PR TITLE
Disabled SSLv3 to fix POODLE vulnerability.

### DIFF
--- a/sites-available/example.com.conf
+++ b/sites-available/example.com.conf
@@ -168,6 +168,9 @@ server {
     ssl_certificate /etc/ssl/certs/example-cert.pem;
     ssl_certificate_key /etc/ssl/private/example.key;
 
+    # Disable SSL v3 protocol to fix POODLE bug.
+    ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
+
     ## Strict Transport Security header for enhanced security. See
     ## http://www.chromium.org/sts. I've set it to 2 hours; set it to
     ## whichever age you want.


### PR DESCRIPTION
https://www.digicert.com/ssl-support/nginx-disabling-ssl-v3.htm