### PR TITLE
Update fastcgi_cache_key

### DIFF
--- a/apps/drupal/microcache_fcgi_auth.conf
+++ b/apps/drupal/microcache_fcgi_auth.conf
@@ -3,7 +3,7 @@
 ## The cache zone referenced.
 fastcgi_cache microcache;
 ## The cache key.
-fastcgi_cache_key $cache_uid@$scheme$host$request_uri;
+fastcgi_cache_key $cache_uid@$scheme$request_method$host$request_uri;
 
 ## For 200 and 301 make the cache valid for 15s.
 fastcgi_cache_valid 200 301 15s;


### PR DESCRIPTION
I had issues while using the microcache_fcgi_auth.conf.

I noticed that a recent commit (https://github.com/perusio/drupal-with-nginx/pull/169) modified the microcache fastcgi_cache_key for anonymous but not for auth.