### PR TITLE
disable access_log in php_fpm_status_vhost

### DIFF
--- a/php_fpm_status_vhost.conf
+++ b/php_fpm_status_vhost.conf
@@ -14,6 +14,7 @@ location = /fpm-status {
         return 404;
     }
     fastcgi_pass www0;
+    access_log off;
 }
 
 ## The ping page is at /ping and returns the string configured at the php-fpm level.
@@ -23,6 +24,7 @@ location = /ping {
         return 404;
     }
     fastcgi_pass www0;
+    access_log off;
 }
 
 ## This is for the second pool. It assumes that you've configured
@@ -37,6 +39,7 @@ location = /fpm-status-zwei {
         return 404;
     }
     fastcgi_pass www1;
+    access_log off;
 }
 
 ## The ping page is at /ping and returns the string configured at the php-fpm level.
@@ -46,6 +49,7 @@ location = /ping-zwei {
         return 404;
     }
     fastcgi_pass www1;
+    access_log off;
 }
 
 ## This is for the third pool that acts as backup. It assumes that
@@ -61,6 +65,7 @@ location = /fpm-status-drei {
         return 404;
     }
     fastcgi_pass phpcgi;
+    access_log off;
 }
 
 ## The ping page is at /ping and returns the string configured at the php-fpm level.
@@ -70,4 +75,5 @@ location = /ping-drei {
         return 404;
     }
     fastcgi_pass phpcgi;
+    access_log off;
 }


### PR DESCRIPTION
since nginx_status_vhost has access_logs disabled, disabling on the
php_fpm_status_vhost urls as well. Lots full of LB checks aren't that
useful.