### PR TITLE
Corrected header to X-Content-Type-Options

### DIFF
--- a/apps/drupal/microcache_fcgi.conf
+++ b/apps/drupal/microcache_fcgi.conf
@@ -39,7 +39,7 @@ expires epoch;
 #add_header X-Frame-Options SAMEORIGIN;
 
 ## Block MIME type sniffing on IE.
-add_header X-Content-Options nosniff;
+add_header X-Content-Type-Options nosniff;
 
 ## Strict Transport Security header for enhanced security. See
 ## http://www.chromium.org/sts. I've set it to 2 hours; set it to


### PR DESCRIPTION
Per https://www.owasp.org/index.php/List_of_useful_HTTP_headers the header name should be 'X-Content-Type-Options'.