### PR TITLE
Cache valid responses for 15s, not 1s in FCGI-auth mode

### DIFF
--- a/apps/drupal/microcache_fcgi.conf
+++ b/apps/drupal/microcache_fcgi.conf
@@ -8,8 +8,8 @@ fastcgi_cache microcache;
 ## The cache key.
 fastcgi_cache_key $scheme$request_method$host$request_uri;
 
-## For 200 and 301 make the cache valid for 1s seconds.
-fastcgi_cache_valid 200 301 1s;
+## For 200 and 301 make the cache valid for 15 seconds.
+fastcgi_cache_valid 200 301 15s;
 ## For 302 make it valid for 1 minute.
 fastcgi_cache_valid 302 1m;
 ## For 404 make it valid 1 second.


### PR DESCRIPTION
This patch increases the response cache time for valid (200/301) requests from 1s to 15s in line with the other operation modes (proxy and FGCI non-auth).