### PR TITLE
Allowed "Well-Known URIs".

### DIFF
--- a/sites-available/example.com.conf
+++ b/sites-available/example.com.conf
@@ -56,6 +56,12 @@ server {
     ## Uncomment if you're proxying to Apache for handling PHP.
     #proxy_http_version 1.1; # keep alive to the Apache upstream
 
+    # Allow "Well-Known URIs" as per RFC 5785.
+    # Necessary for Let’s Encrypt validation server.
+    location ~* ^/.well-known/ {
+        allow all;
+    }
+
     ################################################################
     ### Generic configuration: for most Drupal 7 sites.
     ################################################################


### PR DESCRIPTION
The change allows "Well-Known URIs" as per RFC 5785.

I am not sure if I put this code in the appropriate place though. 
The code is not related to Drupal so I decided not to put it in drupal.conf

The code borrowed from https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/#
Let's encrypt validation server needs it http://letsencrypt.readthedocs.io/en/latest/using.html#webroot
