### PR TITLE
AJAX autocomplete fix

### DIFF
--- a/sites-available/example.com.conf
+++ b/sites-available/example.com.conf
@@ -48,6 +48,12 @@ server {
     root /var/www/sites/example.com;
     index index.php;
 
+    ## If you are experiencing AJAX autocomplete issues,
+    ## uncomment the lines below
+    #if ( $args ~* "^q=(?<query_value>.*)" ) {
+      #rewrite ^/index.php$ $scheme://$host/?q=$query_value? permanent;
+    #}
+
     ## If you're using a Nginx version greater or equal to 1.1.4 then
     ## you can use keep alive connections to the upstream be it
     ## FastCGI or Apache. If that's not the case comment out the line below.


### PR DESCRIPTION
I was getting an error when using entity reference autocomplete fields, as well as some errors with views ajax with the default configuration. I found this snippet online and it 100% fixed the problem! It could be some sort of other server config, I'm not an expert. This is also one of my first pull requests so I apologize if I'm out of line haha! Let me say that this config has worked extremely well and I'm grateful for all of your work. Take it for what it's worth, just a thought! I found others online with the same problem and had a hard time tracking down the right solution.

Thanks!
