### PR TITLE
Update drupal_upload_progress.conf

### DIFF
--- a/apps/drupal/drupal_upload_progress.conf
+++ b/apps/drupal/drupal_upload_progress.conf
@@ -17,7 +17,7 @@ location ~ (?<upload_form_uri>.*)/x-progress-id:(?<upload_id>\d*) {
 ## Now the above rewrite must be matched by a location that
 ## activates it and references the above defined upload
 ## tracking zone.
-location ^~ /progress {
+location ~ ^/progress$ {
     upload_progress_json_output;
     report_uploads uploads;
 }


### PR DESCRIPTION
Urls starting with progress were failing due to this configuration. It'd be nice to use URLs that may start with the word progress.
