### PR TITLE
Add File Type "image/svg+xml" for Compression

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -69,7 +69,7 @@ http {
     gzip_comp_level 1;
     gzip_http_version 1.1;
     gzip_min_length 10;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
     gzip_vary on;
     gzip_proxied any; # Compression for all requests.
     ## No need for regexps. See


### PR DESCRIPTION
I noticed that Drupal 8 logos didn't show up properly. In Chrome following message shown up when trying to visit http://example.com/core/themes/bartik/logo.svg (here "example.com" is a Drupal 8 site) 

> This site can’t be reached
> The webpage at http://example.com/core/themes/bartik/logo.svg might be temporarily down or it may have moved permanently to a new web address.
> ERR_CONTENT_DECODING_FAILED

Similar issue happens in Firefox and Safari as well. However, from what I remember it didn't happen before, so I assume it probably happens only with latest Nginx and/or latest Drupal.

To fix it, I added type "image/svg+xml" for gzip compression.